### PR TITLE
State Normalization

### DIFF
--- a/Tudat/Astrodynamics/BasicAstrodynamics/unifiedStateModelQuaternionsElementConversions.h
+++ b/Tudat/Astrodynamics/BasicAstrodynamics/unifiedStateModelQuaternionsElementConversions.h
@@ -72,7 +72,8 @@ Eigen::Matrix< double, 7, 1 > convertKeplerianToUnifiedStateModelQuaternionsElem
  */
 Eigen::Matrix< double, 6, 1 > convertUnifiedStateModelQuaternionsToKeplerianElements(
         const Eigen::Matrix< double, 7, 1 >& unifiedStateModelElements,
-        const double centralBodyGravitationalParameter );
+        const double centralBodyGravitationalParameter,
+        const bool forceQuaternionNormalization = false );
 
 //! Convert Cartesian elements to unified state model elements with quaternions.
 /*!
@@ -122,7 +123,8 @@ Eigen::Matrix< double, 7, 1 > convertCartesianToUnifiedStateModelQuaternionsElem
 */
 Eigen::Matrix< double, 6, 1 > convertUnifiedStateModelQuaternionsToCartesianElements(
         const Eigen::Matrix< double, 7, 1 >& unifiedStateModelElements,
-        const double centralBodyGravitationalParameter );
+        const double centralBodyGravitationalParameter,
+        const bool forceQuaternionNormalization = false );
 
 } // namespace orbital_element_conversions
 

--- a/Tudat/Astrodynamics/Propagators/dynamicsStateDerivativeModel.h
+++ b/Tudat/Astrodynamics/Propagators/dynamicsStateDerivativeModel.h
@@ -500,6 +500,25 @@ public:
         functionEvaluationCounter_ = 0;
     }
 
+    //! Function to normalize the state vector during propagation.
+    /*!
+     * Function to normalize the state vector during propagation
+     * \param state State before normalization
+     */
+    void normalizeState( Eigen::MatrixXd& state )
+    {
+        for( stateDerivativeModelsIterator_ = stateDerivativeModels_.begin( );
+             stateDerivativeModelsIterator_ != stateDerivativeModels_.end( );
+             stateDerivativeModelsIterator_++ )
+        {
+            for( unsigned int i = 0; i < stateDerivativeModelsIterator_->second.size( ); i++ )
+            {
+                stateDerivativeModelsIterator_->second.at( i )->normalizeState(
+                            state.block( 0, 0, 7, 1 ) );
+            }
+        }
+    }
+
 private:
 
     //! Function to convert the to the conventional form in the global frame per dynamics type.
@@ -571,7 +590,7 @@ private:
     //! state in the full state vector.
     std::map< IntegratedStateType, std::vector< std::pair< int, int > > > conventionalStateIndices_;
 
-    std::map< IntegratedStateType, std::vector< std::pair< int, int > > >propagatedStateIndices_;
+    std::map< IntegratedStateType, std::vector< std::pair< int, int > > > propagatedStateIndices_;
 
     //! State size per state type in the complete state vector.
     std::map< IntegratedStateType, int > conventionalStateTypeSize_;

--- a/Tudat/Astrodynamics/Propagators/dynamicsStateDerivativeModel.h
+++ b/Tudat/Astrodynamics/Propagators/dynamicsStateDerivativeModel.h
@@ -514,7 +514,7 @@ public:
             for( unsigned int i = 0; i < stateDerivativeModelsIterator_->second.size( ); i++ )
             {
                 stateDerivativeModelsIterator_->second.at( i )->normalizeState(
-                            state.block( 0, 0, 7, 1 ) );
+                            state.block( i * 7, 0, 7, 1 ) ); // temporary
             }
         }
     }

--- a/Tudat/Astrodynamics/Propagators/dynamicsStateDerivativeModel.h
+++ b/Tudat/Astrodynamics/Propagators/dynamicsStateDerivativeModel.h
@@ -505,7 +505,7 @@ public:
      * Function to normalize the state vector during propagation
      * \param state State before normalization
      */
-    void normalizeState( Eigen::MatrixXd& state )
+    void normalizeState( Eigen::Matrix< StateScalarType, Eigen::Dynamic, 1 >& state )
     {
         for( stateDerivativeModelsIterator_ = stateDerivativeModels_.begin( );
              stateDerivativeModelsIterator_ != stateDerivativeModels_.end( );
@@ -514,7 +514,7 @@ public:
             for( unsigned int i = 0; i < stateDerivativeModelsIterator_->second.size( ); i++ )
             {
                 stateDerivativeModelsIterator_->second.at( i )->normalizeState(
-                            state.block( i * 7, 0, 7, 1 ) ); // temporary
+                            state, 0 ); // temporary
             }
         }
     }

--- a/Tudat/Astrodynamics/Propagators/integrateEquations.h
+++ b/Tudat/Astrodynamics/Propagators/integrateEquations.h
@@ -435,8 +435,8 @@ boost::shared_ptr< PropagationTerminationDetails > integrateEquationsFromIntegra
         std::map< TimeType, double >& cummulativeComputationTimeHistory,
         const boost::function< Eigen::VectorXd( ) > dependentVariableFunction =
         boost::function< Eigen::VectorXd( ) >( ),
-        boost::function< void( Eigen::MatrixXd& ) > normalizeState =
-        boost::function< void( Eigen::MatrixXd& ) >( ),
+        boost::function< void( StateType& ) > normalizeState =
+        boost::function< void( StateType& ) >( ),
         const int saveFrequency = TUDAT_NAN,
         const TimeType printInterval = TUDAT_NAN,
         const std::chrono::steady_clock::time_point initialClockTime = std::chrono::steady_clock::now( ) )
@@ -642,8 +642,8 @@ public:
             std::map< TimeType, double >& cummulativeComputationTimeHistory,
             const boost::function< Eigen::VectorXd( ) > dependentVariableFunction =
             boost::function< Eigen::VectorXd( ) >( ),
-            boost::function< void( Eigen::MatrixXd& ) > normalizeState =
-            boost::function< void( Eigen::MatrixXd& ) >( ),
+            boost::function< void( StateType& ) > normalizeState =
+            boost::function< void( StateType& ) >( ),
             const TimeType printInterval = TUDAT_NAN,
             const std::chrono::steady_clock::time_point initialClockTime = std::chrono::steady_clock::now( ) );
 };
@@ -684,8 +684,8 @@ public:
             std::map< double, double >& cummulativeComputationTimeHistory,
             const boost::function< Eigen::VectorXd( ) > dependentVariableFunction =
             boost::function< Eigen::VectorXd( ) >( ),
-            boost::function< void( Eigen::MatrixXd& ) > normalizeState =
-            boost::function< void( Eigen::MatrixXd& ) >( ),
+            boost::function< void( StateType& ) > normalizeState =
+            boost::function< void( StateType& ) >( ),
             const double printInterval = TUDAT_NAN,
             const std::chrono::steady_clock::time_point initialClockTime = std::chrono::steady_clock::now( ) )
     {
@@ -750,8 +750,8 @@ public:
             std::map< Time, double >& cummulativeComputationTimeHistory,
             const boost::function< Eigen::VectorXd( ) > dependentVariableFunction =
             boost::function< Eigen::VectorXd( ) >( ),
-            boost::function< void( Eigen::MatrixXd& ) > normalizeState =
-            boost::function< void( Eigen::MatrixXd& ) >( ),
+            boost::function< void( StateType& ) > normalizeState =
+            boost::function< void( StateType& ) >( ),
             const Time printInterval = TUDAT_NAN,
             const std::chrono::steady_clock::time_point initialClockTime = std::chrono::steady_clock::now( ) )
     {

--- a/Tudat/Astrodynamics/Propagators/integrateEquations.h
+++ b/Tudat/Astrodynamics/Propagators/integrateEquations.h
@@ -425,7 +425,7 @@ void propagateToExactTerminationCondition(
  *  By default now(), i.e. the moment at which this function is called.
  *  \return Event that triggered the termination of the propagation
  */
-template< typename StateType = Eigen::MatrixXd, typename TimeType = double, typename TimeStepType = TimeType  >
+template< typename StateType = Eigen::MatrixXd, typename TimeType = double, typename TimeStepType = TimeType >
 boost::shared_ptr< PropagationTerminationDetails > integrateEquationsFromIntegrator(
         const boost::shared_ptr< numerical_integrators::NumericalIntegrator< TimeType, StateType, StateType, TimeStepType > > integrator,
         const TimeStepType initialTimeStep,
@@ -435,6 +435,8 @@ boost::shared_ptr< PropagationTerminationDetails > integrateEquationsFromIntegra
         std::map< TimeType, double >& cummulativeComputationTimeHistory,
         const boost::function< Eigen::VectorXd( ) > dependentVariableFunction =
         boost::function< Eigen::VectorXd( ) >( ),
+        boost::function< void( Eigen::MatrixXd& ) > normalizeState =
+        boost::function< void( Eigen::MatrixXd& ) >( ),
         const int saveFrequency = TUDAT_NAN,
         const TimeType printInterval = TUDAT_NAN,
         const std::chrono::steady_clock::time_point initialClockTime = std::chrono::steady_clock::now( ) )
@@ -486,13 +488,17 @@ boost::shared_ptr< PropagationTerminationDetails > integrateEquationsFromIntegra
 
                 // Perform integration step.
                 newState = integrator->performIntegrationStep( timeStep );
+                if( !normalizeState.empty( ) )
+                {
+                    normalizeState( newState );
+                }
 
                 // Check if the termination condition was reached during evaluation of integration sub-steps.
                 // If evaluation of the termination condition during integration sub-steps is disabled,
                 // this function returns always `false`.
                 // If the termination condition was reached, the last step could not be computed correctly because some
                 // of the integrator sub-steps were not computed. Thus, return immediately without saving the `newState`.
-                if ( integrator->getPropagationTerminationConditionReached() )
+                if( integrator->getPropagationTerminationConditionReached( ) )
                 {
                     propagationTerminationReason = boost::make_shared< PropagationTerminationDetails >(
                                 termination_condition_reached );
@@ -535,10 +541,10 @@ boost::shared_ptr< PropagationTerminationDetails > integrateEquationsFromIntegra
             // Print solutions
             if( printInterval == printInterval )
             {
-                if( ( static_cast<int>( std::fabs( static_cast< double >( currentTime - initialTime ) ) ) %
-                      static_cast< int >( printInterval ) ) <=
-                        ( static_cast< int >( std::fabs( static_cast< double >( previousTime - initialTime ) ) ) %
-                          static_cast<int>( printInterval ) )  )
+                if( ( static_cast< int >( std::fabs( static_cast< double >( currentTime - initialTime ) ) ) %
+                       static_cast< int >( printInterval ) ) <=
+                     ( static_cast< int >( std::fabs( static_cast< double >( previousTime - initialTime ) ) ) %
+                       static_cast< int >( printInterval ) ) )
                 {
                     std::cout << "Current time and state in integration: " << std::setprecision( 10 ) <<
                                  timeStep << " " << currentTime << " " << newState.transpose( ) << std::endl;
@@ -636,6 +642,8 @@ public:
             std::map< TimeType, double >& cummulativeComputationTimeHistory,
             const boost::function< Eigen::VectorXd( ) > dependentVariableFunction =
             boost::function< Eigen::VectorXd( ) >( ),
+            boost::function< void( Eigen::MatrixXd& ) > normalizeState =
+            boost::function< void( Eigen::MatrixXd& ) >( ),
             const TimeType printInterval = TUDAT_NAN,
             const std::chrono::steady_clock::time_point initialClockTime = std::chrono::steady_clock::now( ) );
 };
@@ -676,6 +684,8 @@ public:
             std::map< double, double >& cummulativeComputationTimeHistory,
             const boost::function< Eigen::VectorXd( ) > dependentVariableFunction =
             boost::function< Eigen::VectorXd( ) >( ),
+            boost::function< void( Eigen::MatrixXd& ) > normalizeState =
+            boost::function< void( Eigen::MatrixXd& ) >( ),
             const double printInterval = TUDAT_NAN,
             const std::chrono::steady_clock::time_point initialClockTime = std::chrono::steady_clock::now( ) )
     {
@@ -687,7 +697,7 @@ public:
                 numerical_integrators::createIntegrator< double, StateType >(
                     stateDerivativeFunction, initialState, integratorSettings );
 
-        if ( integratorSettings->assessPropagationTerminationConditionDuringIntegrationSubsteps_ )
+        if( integratorSettings->assessPropagationTerminationConditionDuringIntegrationSubsteps_ )
         {
             integrator->setPropagationTerminationFunction( stopPropagationFunction );
         }
@@ -697,6 +707,7 @@ public:
                     dependentVariableHistory,
                     cummulativeComputationTimeHistory,
                     dependentVariableFunction,
+                    normalizeState,
                     integratorSettings->saveFrequency_,
                     printInterval,
                     initialClockTime );
@@ -739,6 +750,8 @@ public:
             std::map< Time, double >& cummulativeComputationTimeHistory,
             const boost::function< Eigen::VectorXd( ) > dependentVariableFunction =
             boost::function< Eigen::VectorXd( ) >( ),
+            boost::function< void( Eigen::MatrixXd& ) > normalizeState =
+            boost::function< void( Eigen::MatrixXd& ) >( ),
             const Time printInterval = TUDAT_NAN,
             const std::chrono::steady_clock::time_point initialClockTime = std::chrono::steady_clock::now( ) )
     {
@@ -750,7 +763,7 @@ public:
                 numerical_integrators::createIntegrator< Time, StateType, long double  >(
                     stateDerivativeFunction, initialState, integratorSettings );
 
-        if ( integratorSettings->assessPropagationTerminationConditionDuringIntegrationSubsteps_ )
+        if( integratorSettings->assessPropagationTerminationConditionDuringIntegrationSubsteps_ )
         {
             integrator->setPropagationTerminationFunction( stopPropagationFunction );
         }
@@ -760,6 +773,7 @@ public:
                     dependentVariableHistory,
                     cummulativeComputationTimeHistory,
                     dependentVariableFunction,
+                    normalizeState,
                     integratorSettings->saveFrequency_,
                     printInterval,
                     initialClockTime );

--- a/Tudat/Astrodynamics/Propagators/integrateEquations.h
+++ b/Tudat/Astrodynamics/Propagators/integrateEquations.h
@@ -526,7 +526,7 @@ boost::shared_ptr< PropagationTerminationDetails > integrateEquationsFromIntegra
             else
             {
                 std::cerr << "Error, propagation terminated at t=" + std::to_string( static_cast< double >( currentTime ) ) +
-                             ", found Nan/inf entry, returning propagation data up to current time" << std::endl;
+                             ", found NaN/Inf entry, returning propagation data up to current time" << std::endl;
                 breakPropagation = 1;
                 propagationTerminationReason = boost::make_shared< PropagationTerminationDetails >(
                             nan_or_inf_detected_in_state );

--- a/Tudat/Astrodynamics/Propagators/nBodyUnifiedStateModelExponentialMapStateDerivative.h
+++ b/Tudat/Astrodynamics/Propagators/nBodyUnifiedStateModelExponentialMapStateDerivative.h
@@ -231,7 +231,7 @@ public:
     }
 
     void normalizeState(
-            Eigen::Block< Eigen::Matrix< StateScalarType, Eigen::Dynamic, 1 > > unnormalizedState )
+            Eigen::Block< Eigen::Matrix< StateScalarType, Eigen::Dynamic, Eigen::Dynamic > > unnormalizedState )
     {
         // Loop over each body
         for( unsigned int i = 0; i < this->bodiesToBeIntegratedNumerically_.size( ); i++ )

--- a/Tudat/Astrodynamics/Propagators/nBodyUnifiedStateModelExponentialMapStateDerivative.h
+++ b/Tudat/Astrodynamics/Propagators/nBodyUnifiedStateModelExponentialMapStateDerivative.h
@@ -231,7 +231,8 @@ public:
     }
 
     void normalizeState(
-            Eigen::Block< Eigen::Matrix< StateScalarType, Eigen::Dynamic, Eigen::Dynamic > > unnormalizedState )
+            Eigen::Matrix< StateScalarType, Eigen::Dynamic, 1 >& unnormalizedState,
+            const int startRow )
     {
         // Loop over each body
         for( unsigned int i = 0; i < this->bodiesToBeIntegratedNumerically_.size( ); i++ )
@@ -246,7 +247,7 @@ public:
                 exponentialMapVector *= ( 1 - ( 2 * mathematical_constants::PI / exponentialMapMagnitude ) );
 
                 // Replace EM with SEM, or vice-versa
-                unnormalizedState.block( i * 6 + 3, 0, 3, 1 ) = exponentialMapVector;
+                unnormalizedState.segment( startRow + i * 6 + 3, 3 ) = exponentialMapVector;
             }
         }
     }

--- a/Tudat/Astrodynamics/Propagators/nBodyUnifiedStateModelExponentialMapStateDerivative.h
+++ b/Tudat/Astrodynamics/Propagators/nBodyUnifiedStateModelExponentialMapStateDerivative.h
@@ -182,8 +182,8 @@ public:
         for( unsigned int i = 0; i < this->bodiesToBeIntegratedNumerically_.size( ); i++ )
         {
             currentState.segment( i * 6, 6 ) =
-                    orbital_element_conversions::convertCartesianToUnifiedStateModelExponentialMapElements<
-                    StateScalarType >( cartesianSolution.block( i * 6, 0, 6, 1 ), static_cast< StateScalarType >(
+                    orbital_element_conversions::convertCartesianToUnifiedStateModelExponentialMapElements(
+                        cartesianSolution.block( i * 6, 0, 6, 1 ), static_cast< StateScalarType >(
                             centralBodyGravitationalParameters_.at( i )( ) ) );
         }
 
@@ -207,30 +207,12 @@ public:
             const Eigen::Matrix< StateScalarType, Eigen::Dynamic, Eigen::Dynamic >& internalSolution, const TimeType& time,
             Eigen::Block< Eigen::Matrix< StateScalarType, Eigen::Dynamic, 1 > > currentCartesianLocalSoluton )
     {
-        using mathematical_constants::PI;
-
-        Eigen::Matrix< StateScalarType, 3, 1 > exponentialMapVector;
-        StateScalarType exponentialMapMagnitude;
-        Eigen::Matrix< StateScalarType, 6, 1 > currentUnifiedStateModelState;
-
         // Convert state to Cartesian for each body
         for( unsigned int i = 0; i < this->bodiesToBeIntegratedNumerically_.size( ); i++ )
         {
-            // Convert to/from shadow exponential map (SEM) (transformation is the same either way)
-            exponentialMapVector = internalSolution.block( i * 6 + 3, 0, 3, 1 );
-            exponentialMapMagnitude = exponentialMapVector.norm( );
-            if ( exponentialMapMagnitude >= PI )
-            {
-                exponentialMapVector *= ( 1 - ( 2 * PI / exponentialMapMagnitude ) );
-            }
-
-            // Get current solution
-            currentUnifiedStateModelState.segment( 0, 3 ) = internalSolution.block( i * 6, 0, 3, 1 );
-            currentUnifiedStateModelState.segment( 3, 3 ) = exponentialMapVector;
-
             currentCartesianLocalSoluton.segment( i * 6, 6 ) =
-                    orbital_element_conversions::convertUnifiedStateModelExponentialMapToCartesianElements< StateScalarType >(
-                        currentUnifiedStateModelState, static_cast< StateScalarType >(
+                    orbital_element_conversions::convertUnifiedStateModelExponentialMapToCartesianElements(
+                        internalSolution.block( i * 6, 0, 6, 1 ), static_cast< StateScalarType >(
                             centralBodyGravitationalParameters_.at( i )( ) ) );
         }
 
@@ -246,6 +228,27 @@ public:
     basic_astrodynamics::AccelerationMap getFullAccelerationsMap( )
     {
         return originalAccelerationModelsPerBody_;
+    }
+
+    void normalizeState(
+            Eigen::Block< Eigen::Matrix< StateScalarType, Eigen::Dynamic, 1 > > unnormalizedState )
+    {
+        // Loop over each body
+        for( unsigned int i = 0; i < this->bodiesToBeIntegratedNumerically_.size( ); i++ )
+        {
+            // Convert to/from shadow exponential map (SEM) (transformation is the same either way)
+            Eigen::Matrix< StateScalarType, 3, 1 > exponentialMapVector =
+                    unnormalizedState.block( i * 6 + 3, 0, 3, 1 );
+            StateScalarType exponentialMapMagnitude = exponentialMapVector.norm( );
+            if ( exponentialMapMagnitude >= mathematical_constants::PI )
+            {
+                // Convert to EM/SEM
+                exponentialMapVector *= ( 1 - ( 2 * mathematical_constants::PI / exponentialMapMagnitude ) );
+
+                // Replace EM with SEM, or vice-versa
+                unnormalizedState.block( i * 6 + 3, 0, 3, 1 ) = exponentialMapVector;
+            }
+        }
     }
 
 private:

--- a/Tudat/Astrodynamics/Propagators/nBodyUnifiedStateModelModifiedRodriguesParametersStateDerivative.h
+++ b/Tudat/Astrodynamics/Propagators/nBodyUnifiedStateModelModifiedRodriguesParametersStateDerivative.h
@@ -237,7 +237,7 @@ public:
     }
 
     void normalizeState(
-            Eigen::Block< Eigen::Matrix< StateScalarType, Eigen::Dynamic, 1 > > unnormalizedState )
+            Eigen::Block< Eigen::Matrix< StateScalarType, Eigen::Dynamic, Eigen::Dynamic > > unnormalizedState )
     {
         // Loop over each body
         for( unsigned int i = 0; i < this->bodiesToBeIntegratedNumerically_.size( ); i++ )

--- a/Tudat/Astrodynamics/Propagators/nBodyUnifiedStateModelModifiedRodriguesParametersStateDerivative.h
+++ b/Tudat/Astrodynamics/Propagators/nBodyUnifiedStateModelModifiedRodriguesParametersStateDerivative.h
@@ -237,7 +237,8 @@ public:
     }
 
     void normalizeState(
-            Eigen::Block< Eigen::Matrix< StateScalarType, Eigen::Dynamic, Eigen::Dynamic > > unnormalizedState )
+            Eigen::Matrix< StateScalarType, Eigen::Dynamic, 1 >& unnormalizedState,
+            const int startRow )
     {
         // Loop over each body
         for( unsigned int i = 0; i < this->bodiesToBeIntegratedNumerically_.size( ); i++ )
@@ -253,7 +254,7 @@ public:
                         modifiedRodriguesParametersMagnitude;
 
                 // Replace MRP with SMPR, or vice-versa
-                unnormalizedState.block( i * 7 + 3, 0, 3, 1 ) = modifiedRodriguesParametersVector;
+                unnormalizedState.segment( startRow + i * 7 + 3, 3 ) = modifiedRodriguesParametersVector;
 
                 // Invert flag
 //                unnormalizedState.block( i * 7 + 6, 0, 1, 1 ) = !unnormalizedState.block( i * 7 + 6, 0, 1, 1 );

--- a/Tudat/Astrodynamics/Propagators/nBodyUnifiedStateModelQuaternionsStateDerivative.cpp
+++ b/Tudat/Astrodynamics/Propagators/nBodyUnifiedStateModelQuaternionsStateDerivative.cpp
@@ -37,16 +37,6 @@ Eigen::Vector7d computeStateDerivativeForUnifiedStateModelQuaternions(
     hodographMatrix( 2, 1 ) = ( 1.0 + pAuxiliaryVector( 0 ) ) * cosineLambda;
     hodographMatrix( 2, 2 ) = gammaParameter * pAuxiliaryVector( 2 );
 
-    // Normalize quaternions
-//    Eigen::Vector4d quaternionsVector = currentUnifiedStateModelElements.segment( 3, 4 );
-//    double quaternionsMagntiude = quaternionsVector.norm( );
-//    quaternionsVector /= quaternionsMagntiude;
-
-//    double offsetFromUnitNorm = 1.0 - currentUnifiedStateModelElements.segment( 3, 4 ).norm( );
-//    double rotationalVelocityMagnitude = rotationalVelocityVector.norm( ); // gain value
-//    Eigen::Matrix4d quaternionMatrix = rotationalVelocityMagnitude * offsetFromUnitNorm *
-//            Eigen::Matrix4d::Identity( ); // normalize quaternions during propagation
-                                          // (reference: W. F. Phillips, Mechanics of Flight, 2004)
     Eigen::Matrix4d quaternionMatrix = Eigen::Matrix4d::Zero( );
     quaternionMatrix( 0, 1 ) =   rotationalVelocityVector( 2 );
     quaternionMatrix( 0, 3 ) =   rotationalVelocityVector( 0 );
@@ -60,9 +50,6 @@ Eigen::Vector7d computeStateDerivativeForUnifiedStateModelQuaternions(
     // Evaluate USM7 equations.
     Eigen::Vector7d stateDerivative = Eigen::Vector7d::Zero( );
     stateDerivative.segment( 0, 3 ) = hodographMatrix * accelerationsInRswFrame;
-//    Eigen::Vector4d quaternionsDerivative = 0.5 * quaternionMatrix * quaternionsVector;
-//    stateDerivative.segment( 3, 4 ) = quaternionsDerivative -
-//            quaternionsVector.dot( quaternionsDerivative ) * quaternionsVector; // normalize derivative
     stateDerivative.segment( 3, 4 ) = 0.5 * quaternionMatrix * currentUnifiedStateModelElements.segment( 3, 4 );
 
     // Give output
@@ -78,17 +65,17 @@ Eigen::Vector7d computeStateDerivativeForUnifiedStateModelQuaternions(
     using namespace orbital_element_conversions;
 
     // Retrieve USM elements
-    double epsilon1Quaternion = currentUnifiedStateModelElements( epsilon1QuaternionIndex );
-    double epsilon2Quaternion = currentUnifiedStateModelElements( epsilon2QuaternionIndex );
-    double epsilon3Quaternion = currentUnifiedStateModelElements( epsilon3QuaternionIndex );
-    double etaQuaternion = currentUnifiedStateModelElements( etaQuaternionIndex );
+    double epsilon1QuaternionParameter = currentUnifiedStateModelElements( epsilon1QuaternionIndex );
+    double epsilon2QuaternionParameter = currentUnifiedStateModelElements( epsilon2QuaternionIndex );
+    double epsilon3QuaternionParameter = currentUnifiedStateModelElements( epsilon3QuaternionIndex );
+    double etaQuaternionParameter = currentUnifiedStateModelElements( etaQuaternionIndex );
 
     // Compute supporting parameters
-    double denominator = std::pow( epsilon3Quaternion, 2 ) + std::pow( etaQuaternion, 2 );
-    double sineLambda = ( 2 * epsilon3Quaternion * etaQuaternion ) / denominator;
-    double cosineLambda =  ( std::pow( etaQuaternion, 2 ) - std::pow( epsilon3Quaternion, 2 ) ) / denominator;
-    double gammaParameter = ( epsilon1Quaternion * epsilon3Quaternion -
-                              epsilon2Quaternion * etaQuaternion ) / denominator;
+    double denominator = std::pow( epsilon3QuaternionParameter, 2 ) + std::pow( etaQuaternionParameter, 2 );
+    double sineLambda = ( 2 * epsilon3QuaternionParameter * etaQuaternionParameter ) / denominator;
+    double cosineLambda =  ( std::pow( etaQuaternionParameter, 2 ) - std::pow( epsilon3QuaternionParameter, 2 ) ) / denominator;
+    double gammaParameter = ( epsilon1QuaternionParameter * epsilon3QuaternionParameter -
+                              epsilon2QuaternionParameter * etaQuaternionParameter ) / denominator;
 
     double velocityHodographParameter = currentUnifiedStateModelElements( CHodographQuaternionIndex ) -
             currentUnifiedStateModelElements( Rf1HodographQuaternionIndex ) * sineLambda +

--- a/Tudat/Astrodynamics/Propagators/nBodyUnifiedStateModelQuaternionsStateDerivative.h
+++ b/Tudat/Astrodynamics/Propagators/nBodyUnifiedStateModelQuaternionsStateDerivative.h
@@ -235,7 +235,8 @@ public:
     }
 
     void normalizeState(
-            Eigen::Block< Eigen::Matrix< StateScalarType, Eigen::Dynamic, Eigen::Dynamic > > unnormalizedState )
+            Eigen::Matrix< StateScalarType, Eigen::Dynamic, 1 >& unnormalizedState,
+            const int startRow )
     {
         // Loop over each body
         for( unsigned int i = 0; i < this->bodiesToBeIntegratedNumerically_.size( ); i++ )
@@ -250,7 +251,7 @@ public:
                 quaternionsVector /= quaternionsMagnitude;
 
                 // Replace old quaternions with normalized quaternions
-                unnormalizedState.block( i * 7 + 3, 0, 4, 1 ) = quaternionsVector;
+                unnormalizedState.segment( startRow + i * 7 + 3, 4 ) = quaternionsVector;
             }
         }
     }

--- a/Tudat/Astrodynamics/Propagators/nBodyUnifiedStateModelQuaternionsStateDerivative.h
+++ b/Tudat/Astrodynamics/Propagators/nBodyUnifiedStateModelQuaternionsStateDerivative.h
@@ -212,7 +212,7 @@ public:
             currentCartesianLocalSoluton.segment( i * 6, 6 ) =
                     orbital_element_conversions::convertUnifiedStateModelQuaternionsToCartesianElements(
                         internalSolution.block( i * 7, 0, 7, 1 ), static_cast< StateScalarType >(
-                            centralBodyGravitationalParameters_.at( i )( ) ) );
+                            centralBodyGravitationalParameters_.at( i )( ) ), true ); // force normalization of quaternions
         }
 
         currentCartesianLocalSoluton_ = currentCartesianLocalSoluton;

--- a/Tudat/Astrodynamics/Propagators/nBodyUnifiedStateModelQuaternionsStateDerivative.h
+++ b/Tudat/Astrodynamics/Propagators/nBodyUnifiedStateModelQuaternionsStateDerivative.h
@@ -235,7 +235,7 @@ public:
     }
 
     void normalizeState(
-            Eigen::Block< Eigen::Matrix< StateScalarType, Eigen::Dynamic, 1 > > unnormalizedState )
+            Eigen::Block< Eigen::Matrix< StateScalarType, Eigen::Dynamic, Eigen::Dynamic > > unnormalizedState )
     {
         // Loop over each body
         for( unsigned int i = 0; i < this->bodiesToBeIntegratedNumerically_.size( ); i++ )

--- a/Tudat/Astrodynamics/Propagators/singleStateTypeDerivative.h
+++ b/Tudat/Astrodynamics/Propagators/singleStateTypeDerivative.h
@@ -180,11 +180,21 @@ public:
         return integratedStateType_;
     }
 
+    //! Function to normalize the state vector during propagation.
+    /*!
+     * Function to normalize the state vector during propagation
+     * \param unnormalizedState State before normalization
+     */
     virtual void normalizeState(
             Eigen::Block< Eigen::Matrix< StateScalarType, Eigen::Dynamic, 1 > > unnormalizedState )
     {
 
     }
+
+//    virtual bool isStateNormalized( )
+//    {
+//        return false;
+//    }
 
 protected:
 

--- a/Tudat/Astrodynamics/Propagators/singleStateTypeDerivative.h
+++ b/Tudat/Astrodynamics/Propagators/singleStateTypeDerivative.h
@@ -186,7 +186,8 @@ public:
      * \param unnormalizedState State before normalization
      */
     virtual void normalizeState(
-            Eigen::Block< Eigen::Matrix< StateScalarType, Eigen::Dynamic, Eigen::Dynamic > > unnormalizedState )
+            Eigen::Matrix< StateScalarType, Eigen::Dynamic, 1 >& unnormalizedState,
+            const int startRow )
     {
 
     }

--- a/Tudat/Astrodynamics/Propagators/singleStateTypeDerivative.h
+++ b/Tudat/Astrodynamics/Propagators/singleStateTypeDerivative.h
@@ -186,7 +186,7 @@ public:
      * \param unnormalizedState State before normalization
      */
     virtual void normalizeState(
-            Eigen::Block< Eigen::Matrix< StateScalarType, Eigen::Dynamic, 1 > > unnormalizedState )
+            Eigen::Block< Eigen::Matrix< StateScalarType, Eigen::Dynamic, Eigen::Dynamic > > unnormalizedState )
     {
 
     }

--- a/Tudat/Mathematics/NumericalIntegrators/createNumericalIntegrator.h
+++ b/Tudat/Mathematics/NumericalIntegrators/createNumericalIntegrator.h
@@ -396,18 +396,19 @@ DependentVariableType, TimeStepType > > createIntegrator(
     switch( integratorSettings->integratorType_ )
     {
     case euler:
+    {
         integrator = boost::make_shared< EulerIntegrator
                 < IndependentVariableType, DependentVariableType, DependentVariableType, TimeStepType > >
                 ( stateDerivativeFunction, integratorSettings->initialTime_, initialState ) ;
         break;
+    }
     case rungeKutta4:
-
+    {
         integrator = boost::make_shared< RungeKutta4Integrator
                 < IndependentVariableType, DependentVariableType, DependentVariableType, TimeStepType > >
                 ( stateDerivativeFunction, integratorSettings->initialTime_, initialState ) ;
         break;
-
-
+    }
     case rungeKuttaVariableStepSize:
     {
         // Check input consistency

--- a/Tudat/SimulationSetup/PropagationSetup/dynamicsSimulator.h
+++ b/Tudat/SimulationSetup/PropagationSetup/dynamicsSimulator.h
@@ -434,6 +434,7 @@ public:
                     dependentVariableHistory_,
                     cummulativeComputationTimeHistory_,
                     dependentVariablesFunctions_,
+                    stateNormalizingFunction_,
                     propagatorSettings_->getPrintInterval( ),
                     initialClockTime_ );
         dynamicsStateDerivative_->convertNumericalStateSolutionsToOutputSolutions(
@@ -501,7 +502,6 @@ public:
     {
         return std::vector< std::map< TimeType, double > >( { getCummulativeComputationTimeHistory( ) } );
     }
-
 
     //! Function to reset the environment from an externally generated state history.
     /*!
@@ -583,7 +583,6 @@ public:
     {
         return dynamicsStateDerivative_;
     }
-
 
     //! Function to retrieve the object defining when the propagation is to be terminated.
     /*!
@@ -747,6 +746,11 @@ protected:
 
     //! Function returning dependent variables (during numerical propagation)
     boost::function< Eigen::VectorXd( ) > dependentVariablesFunctions_;
+
+    //! Function to normalize state (during numerical propagation)
+    boost::function< void( Eigen::MatrixXd& ) > stateNormalizingFunction_ =
+            boost::bind( &DynamicsStateDerivativeModel< TimeType, StateScalarType >::normalizeState,
+                         dynamicsStateDerivative_, _1, _2 );
 
     //! Map listing starting entry of dependent variables in output vector, along with associated ID.
     std::map< int, std::string > dependentVariableIds_;

--- a/Tudat/SimulationSetup/PropagationSetup/dynamicsSimulator.h
+++ b/Tudat/SimulationSetup/PropagationSetup/dynamicsSimulator.h
@@ -751,7 +751,7 @@ protected:
     boost::function< Eigen::VectorXd( ) > dependentVariablesFunctions_;
 
     //! Function to normalize state (during numerical propagation)
-    boost::function< void( Eigen::Matrix< StateScalarType, Eigen::Dynamic, Eigen::Dynamic >& ) > stateNormalizingFunction_;
+    boost::function< void( Eigen::Matrix< StateScalarType, Eigen::Dynamic, 1 >& ) > stateNormalizingFunction_;
 
     //! Map listing starting entry of dependent variables in output vector, along with associated ID.
     std::map< int, std::string > dependentVariableIds_;

--- a/Tudat/SimulationSetup/PropagationSetup/dynamicsSimulator.h
+++ b/Tudat/SimulationSetup/PropagationSetup/dynamicsSimulator.h
@@ -750,7 +750,7 @@ protected:
     //! Function to normalize state (during numerical propagation)
     boost::function< void( Eigen::MatrixXd& ) > stateNormalizingFunction_ =
             boost::bind( &DynamicsStateDerivativeModel< TimeType, StateScalarType >::normalizeState,
-                         dynamicsStateDerivative_, _1, _2 );
+                         dynamicsStateDerivative_, _1 );
 
     //! Map listing starting entry of dependent variables in output vector, along with associated ID.
     std::map< int, std::string > dependentVariableIds_;

--- a/Tudat/SimulationSetup/PropagationSetup/dynamicsSimulator.h
+++ b/Tudat/SimulationSetup/PropagationSetup/dynamicsSimulator.h
@@ -390,6 +390,9 @@ public:
         doubleStateDerivativeFunction_ =
                 boost::bind( &DynamicsStateDerivativeModel< TimeType, StateScalarType >::computeStateDoubleDerivative,
                              dynamicsStateDerivative_, _1, _2 );
+        stateNormalizingFunction_ =
+                boost::bind( &DynamicsStateDerivativeModel< TimeType, StateScalarType >::normalizeState,
+                             dynamicsStateDerivative_, _1 );
 
         // Integrate equations of motion if required.
         if( areEquationsOfMotionToBeIntegrated )
@@ -748,9 +751,7 @@ protected:
     boost::function< Eigen::VectorXd( ) > dependentVariablesFunctions_;
 
     //! Function to normalize state (during numerical propagation)
-    boost::function< void( Eigen::MatrixXd& ) > stateNormalizingFunction_ =
-            boost::bind( &DynamicsStateDerivativeModel< TimeType, StateScalarType >::normalizeState,
-                         dynamicsStateDerivative_, _1 );
+    boost::function< void( Eigen::Matrix< StateScalarType, Eigen::Dynamic, Eigen::Dynamic >& ) > stateNormalizingFunction_;
 
     //! Map listing starting entry of dependent variables in output vector, along with associated ID.
     std::map< int, std::string > dependentVariableIds_;


### PR DESCRIPTION
State can now be processed right after the propagation step. This is useful, for instance, for normalization of quaternions. 